### PR TITLE
feat: update addAsset scripts

### DIFF
--- a/src/config/inter/addVault/add-oracle-permit.json
+++ b/src/config/inter/addVault/add-oracle-permit.json
@@ -11,22 +11,20 @@
     "priceAuthority": "priceFeed",
     "priceAuthorityAdmin": "priceFeed",
     "startGovernedUpgradable": "priceFeed",
-    "vatAdminSvc": "makeCoreProposalBehavior",
-    "zoe": "makeCoreProposalBehavior"
+    "zoe": "priceFeed",
+    "vatAdminSvc": "makeCoreProposalBehavior"
   },
-  "installation": {},
   "instance": {
     "produce": "priceFeed"
   },
-  "namedVat": {
-    "consume": {
-      "agoricNames": "agoricNames"
-    }
-  },
+  "namedVat":  true,
   "oracleBrand": {
     "produce": "priceFeed"
   },
   "evaluateBundleCap": "makeCoreProposalBehavior",
+  "installation": {
+    "produce": "makeCoreProposalBehavior"
+  },
   "modules": {
     "utils": {
       "runModuleBehaviors": "makeCoreProposalBehavior"

--- a/src/config/inter/addVault/add-oracle.js
+++ b/src/config/inter/addVault/add-oracle.js
@@ -22,7 +22,7 @@ const getManifestCall = harden([
       maxSubmissionCount: 1000,
       maxSubmissionValue:
         115792089237316195423570985008687907853269984665640564039457584007913129639936n,
-      minSubmissionCount: 3,
+      minSubmissionCount: 3, // TODO: parameterize
       minSubmissionValue: 1n,
       restartDelay: 1,
       timeout: 10,
@@ -31,7 +31,7 @@ const getManifestCall = harden([
       "%%NoracleAddressesN%%"
     ],
     priceAggregatorRef: {
-      bundleID: "b1-991f5fece438a302e710b2612f67a5bafd23362dc6e1a27228e3b6be3775cb07ef1d1456f3259256dc572effb7c671d8c882a3251b7551bf08e7f93f7d4c71e1",
+      bundleID: "b1-eca5ebeecb317450e049b450fa6449287844a324b0385cbc73e320adef79a168c71ffe441e95ef4ce7b4d15e62bb01ed87dace27d09646609ae3f20c5496a3e9",
     },
   },
 ]);

--- a/src/config/inter/addVault/add-oracle.js
+++ b/src/config/inter/addVault/add-oracle.js
@@ -3,7 +3,7 @@
 
 const manifestBundleRef = {
   bundleID:
-    "b1-4fa91236698b96550e441179909297b8df96deea6a53bd3d5ae27415d0cab5cf620b8243a70e82a0c27807da572bf90a2094e169cb872e72fa975988b0a8257c"
+    "b1-c016d741a13041e8eefbd05fc5f645113e10beba55fdce2d5ed979bbb1c95077cf2edbe359d588e28bf68d837665458e65c1d534d32f090125951458c461a829"
 };
 const getManifestCall = harden([
   "getManifestForPriceFeed",

--- a/src/config/inter/addVault/add-vault-permit.json
+++ b/src/config/inter/addVault/add-vault-permit.json
@@ -20,7 +20,8 @@
     "consume": {
       "mintHolder": true,
       "scaledPriceAuthority": true
-    }
+    },
+    "produce": true
   },
   "instance": {
     "produce": true,

--- a/src/config/inter/addVault/add-vault.js
+++ b/src/config/inter/addVault/add-vault.js
@@ -3,7 +3,7 @@
 
 const manifestBundleRef = {
   bundleID:
-    "b1-c676347a9ebe38af9bcfb6e18616e7faeff31b5ce5cee8e600a0e880587ce733c7ee2afcf01dd2e782c1a57ceb861a262ad96747b8962c055a17090c5609afc5"
+    "b1-3ac516e8bb37fa0d6d493176649fab362c32b395bc614647aafbbd07b22f35c587c3bc8c6bcaa1a7f7e3606aa10ef695dda037532ce90818cf9d0fa4b2999c21"
 };
 const getManifestCall = harden([
   "getManifestForAddAssetToVault",
@@ -22,7 +22,7 @@ const getManifestCall = harden([
     },
     interestRateValue: undefined,
     scaledPriceAuthorityRef: {
-      bundleID: "b1-affe49a2fd32d6f7a7453790f704fbb4e0180e9cba21439f46016c5add3378987a42ac3d540ec587321de52eadc98a19ff72354e1d058744315efced2b11494d",
+      bundleID: "b1-f8e2677e8dede9ccf194f31e8ed3183649fcb97cf22a17cb6b99883f27f38e3035bb3bf1d101ee008a9f6625de70b992cda94bd80f8ce5df1b812ace7cc2192e",
     },
   },
 ]);


### PR DESCRIPTION
closes: #60
replaces: #61

update some bundleIds and permissions

Once these repairs are made, you'll also have to upload these bundles. The contract bundles below (the first two) differ from their counterparts uploaded to mainNet only by having comments replaced by `blankSpece`. The latter two bundles are the proposals.

**priceAggregatorRef**: `b1-eca5ebeecb317450e049b450fa6449287844a324b0385cbc73e320adef79a168c71ffe441e95ef4ce7b4d15e62bb01ed87dace27d09646609ae3f20c5496a3e9`

**scaledPriceAuthorityRef**
`b1-f8e2677e8dede9ccf194f31e8ed3183649fcb97cf22a17cb6b99883f27f38e3035bb3bf1d101ee008a9f6625de70b992cda94bd80f8ce5df1b812ace7cc2192e`

**add-oracle**:
    `b1-c016d741a13041e8eefbd05fc5f645113e10beba55fdce2d5ed979bbb1c95077cf2edbe359d588e28bf68d837665458e65c1d534d32f090125951458c461a829`

**add-vault**
   `b1-3ac516e8bb37fa0d6d493176649fab362c32b395bc614647aafbbd07b22f35c587c3bc8c6bcaa1a7f7e3606aa10ef695dda037532ce90818cf9d0fa4b2999c21`
