### PR TITLE
feat(agoric): support mint parameter governance updates

### DIFF
--- a/src/components/ParameterChangeForm.tsx
+++ b/src/components/ParameterChangeForm.tsx
@@ -146,6 +146,7 @@ function ParameterChangeFormSectionBase<T, R extends FormValue[] | undefined>(
               transformValue={transformValue}
               valueKey={activeParamDesc.valueKey || ("value" as string)}
               inputType={activeParamDesc.inputType || "string"}
+              readOnlyKeys={activeParamDesc.readOnlyKeys}
             />
           </div>
         </div>

--- a/src/config/agoric/agoric.tsx
+++ b/src/config/agoric/agoric.tsx
@@ -13,6 +13,7 @@ import {
   makeInstallBundleMsg,
   makeSendChunkMsg,
   makeParamChangeProposalMsg,
+  makeMintUpdateParamsProposalMsg,
   makeCommunityPoolSpendProposalMsg,
 } from "../../lib/messageBuilder";
 import { makeSignAndBroadcast } from "../../lib/signAndBroadcast";
@@ -28,7 +29,7 @@ import {
   swingSetParamsQuery,
 } from "../../lib/queries.ts";
 import { selectCoinBalance } from "../../lib/selectors.ts";
-import { DepositParams, VotingParams } from "../../types/gov.ts";
+import { DepositParams, MintParams, VotingParams } from "../../types/gov.ts";
 
 const locale = "en";
 
@@ -46,6 +47,14 @@ const pluralRules = new Intl.PluralRules(locale);
 const pluralizeEn = (count: number, singular: string, plural: string) => {
   const category = pluralRules.select(count);
   return category === "one" ? `${count} ${singular}` : `${count} ${plural}`;
+};
+
+const parseSerializedValue = (value: string) => {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
 };
 
 const Agoric = () => {
@@ -181,10 +190,60 @@ const Agoric = () => {
 
       if (msgType === "parameterChangeProposal") {
         if (vals.msgType !== "parameterChangeProposal") return;
-        proposalMsg = makeParamChangeProposalMsg({
-          ...vals,
-          proposer: walletAddress,
-        });
+        const isMintUpdate = vals.changes.some(
+          ({ subspace }) => subspace === "mint",
+        );
+        if (isMintUpdate) {
+          if (!api) {
+            toast.error("Please select a network!", { autoClose: 3000 });
+            throw new Error("api not found");
+          }
+          const [{ params }, { account }] = await Promise.all([
+            fetch(`${api}/cosmos/mint/v1beta1/params`).then((res) =>
+              res.json(),
+            ),
+            fetch(`${api}/cosmos/auth/v1beta1/module_accounts/gov`).then(
+              (res) => res.json(),
+            ),
+          ]);
+
+          const currentParams = params as MintParams;
+          const govAuthority = account?.base_account?.address as
+            | string
+            | undefined;
+          if (!govAuthority) {
+            throw new Error("Could not resolve gov module authority address.");
+          }
+
+          const patch = vals.changes.reduce<Partial<MintParams>>(
+            (acc, change) => {
+              const key = change.key as keyof MintParams;
+              const parsed = String(
+                parseSerializedValue(change.value as string),
+              );
+              acc[key] = parsed;
+              return acc;
+            },
+            {},
+          );
+          const nextParams = {
+            ...currentParams,
+            ...patch,
+          } as MintParams;
+          proposalMsg = makeMintUpdateParamsProposalMsg({
+            title: vals.title,
+            description: vals.description,
+            proposer: walletAddress,
+            deposit: vals.deposit,
+            authority: govAuthority,
+            params: nextParams,
+          });
+        } else {
+          proposalMsg = makeParamChangeProposalMsg({
+            ...vals,
+            proposer: walletAddress,
+          });
+        }
       }
       if (!proposalMsg) throw new Error("Error parsing query or inputs.");
 

--- a/src/config/agoric/params.ts
+++ b/src/config/agoric/params.ts
@@ -3,9 +3,11 @@ import {
   swingSetParamsQuery,
   tallyParamsQuery,
   votingParamsQuery,
+  mintParamsQuery,
 } from "../../lib/queries";
 import {
   selectBeansPerUnit,
+  selectMintParams,
   selectTallyParams,
   selectVotingParams,
 } from "../../lib/selectors";
@@ -13,17 +15,19 @@ import type { Coin } from "../../types/bank";
 import { scaleToDenomBase, scaleFromDenomBase } from "../../utils/coin";
 import { arrayToObject } from "../../utils/object";
 import { SwingSetParams } from "../../types/swingset";
-import { TallyParams, VotingParams } from "../../types/gov";
+import { MintParams, TallyParams, VotingParams } from "../../types/gov";
 
 export type QueryType =
   | ReturnType<typeof swingSetParamsQuery>
   | ReturnType<typeof tallyParamsQuery>
-  | ReturnType<typeof votingParamsQuery>;
+  | ReturnType<typeof votingParamsQuery>
+  | ReturnType<typeof mintParamsQuery>;
 
 export type SelectorReturnType =
   | ReturnType<typeof selectBeansPerUnit>
   | ReturnType<typeof selectTallyParams>
-  | ReturnType<typeof selectVotingParams>;
+  | ReturnType<typeof selectVotingParams>
+  | ReturnType<typeof selectMintParams>;
 
 export const paramDescriptors = [
   {
@@ -129,5 +133,27 @@ export const paramDescriptors = [
   } as ParameterChangeTypeDescriptor<
     VotingParams,
     ReturnType<typeof selectVotingParams>
+  >,
+  {
+    title: "Mint Parameters",
+    description: "Configure mint parameters (except blocks_per_year).",
+    subspace: "mint",
+    key: "mint_params",
+    valueKey: undefined, // defaults to value
+    transformColumn: undefined,
+    headers: ["Key", "Value"],
+    inputType: "string",
+    readOnlyKeys: ["mint_denom", "blocks_per_year"],
+    query: mintParamsQuery,
+    selector: selectMintParams,
+    submitFn: (values) =>
+      (values as { key: string; value: string }[]).map(({ key, value }) => ({
+        subspace: "mint",
+        key,
+        value: JSON.stringify(value),
+      })),
+  } as ParameterChangeTypeDescriptor<
+    MintParams,
+    ReturnType<typeof selectMintParams>
   >,
 ];

--- a/src/contexts/wallet.tsx
+++ b/src/contexts/wallet.tsx
@@ -13,6 +13,7 @@ import { useNetwork, NetName } from "../hooks/useNetwork";
 import { suggestChain } from "../lib/suggestChain";
 import { getNetConfigUrl } from "../lib/getNetworkConfig";
 import { registry } from "../lib/messageBuilder";
+import { toast } from "react-toastify";
 
 interface WalletContext {
   walletAddress: string | null;
@@ -55,6 +56,11 @@ export const WalletContextProvider = ({
   };
 
   const connectWallet = useCallback(async () => {
+    if (!netName) {
+      toast.error("Please select a network first.", { autoClose: 3000 });
+      return;
+    }
+
     setIsLoading(true);
     const { chainId, rpc } = await suggestChain(
       getNetConfigUrl(netName as NetName),

--- a/src/lib/messageBuilder.spec.ts
+++ b/src/lib/messageBuilder.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { MsgUpdateParams as MintMsgUpdateParams } from "cosmjs-types/cosmos/mint/v1beta1/tx";
+import { makeMintUpdateParamsProposalMsg } from "./messageBuilder";
+
+describe("makeMintUpdateParamsProposalMsg", () => {
+  it("encodes mint params from on-chain integration testing into protobuf LegacyDec atomics", () => {
+    const proposal = makeMintUpdateParamsProposalMsg({
+      // Uses values captured during devnet on-chain integration testing.
+      // Proposer account existence is not required for this encode/decode unit test.
+      title: "mint test",
+      description:
+        "testing https://github.com/DCFoundation/cosmos-proposal-builder/pull/75",
+      proposer: "agoric140dmkrz2e42ergjj7gyvejhzmjzurvqeq82ang",
+      authority: "agoric10d07y265gmmuvt4z0w9aw880jnsr700jgl36x9",
+      params: {
+        mint_denom: "ubld",
+        inflation_rate_change: "0.003000000000000000",
+        inflation_max: "0.000000000000000000",
+        inflation_min: "0.000000000000000000",
+        goal_bonded: "0.67",
+        blocks_per_year: "6311520",
+      },
+    });
+
+    const submitProposal = proposal.value;
+    const encodedMintMsg = submitProposal.messages[0]?.value;
+    if (!encodedMintMsg) {
+      throw new Error("expected mint message bytes");
+    }
+
+    const decodedMintMsg = MintMsgUpdateParams.decode(encodedMintMsg);
+    expect(decodedMintMsg.authority).toBe(
+      "agoric10d07y265gmmuvt4z0w9aw880jnsr700jgl36x9",
+    );
+    expect(decodedMintMsg.params?.mintDenom).toBe("ubld");
+    // LegacyDec customtype encodes in protobuf as 10^18 atomics text.
+    expect(decodedMintMsg.params?.inflationRateChange).toBe("3000000000000000");
+    expect(decodedMintMsg.params?.inflationMax).toBe("0");
+    expect(decodedMintMsg.params?.inflationMin).toBe("0");
+    expect(decodedMintMsg.params?.goalBonded).toBe("670000000000000000");
+    expect(decodedMintMsg.params?.blocksPerYear).toBe(6311520n);
+  });
+
+  it("scales whole-number LegacyDec inputs to 18-decimal atomics", () => {
+    const proposal = makeMintUpdateParamsProposalMsg({
+      title: "mint integer scaling test",
+      description: "test integer values are scaled for LegacyDec protobuf fields",
+      proposer: "agoric140dmkrz2e42ergjj7gyvejhzmjzurvqeq82ang",
+      authority: "agoric10d07y265gmmuvt4z0w9aw880jnsr700jgl36x9",
+      params: {
+        mint_denom: "ubld",
+        inflation_rate_change: "0",
+        inflation_max: "2",
+        inflation_min: "0",
+        goal_bonded: "1",
+        blocks_per_year: "6311520",
+      },
+    });
+
+    const submitProposal = proposal.value;
+    const encodedMintMsg = submitProposal.messages[0]?.value;
+    if (!encodedMintMsg) {
+      throw new Error("expected mint message bytes");
+    }
+
+    const decodedMintMsg = MintMsgUpdateParams.decode(encodedMintMsg);
+    expect(decodedMintMsg.params?.goalBonded).toBe("1000000000000000000");
+    expect(decodedMintMsg.params?.inflationMax).toBe("2000000000000000000");
+  });
+});

--- a/src/lib/queries.e2e.tsx
+++ b/src/lib/queries.e2e.tsx
@@ -12,6 +12,7 @@ import {
   votingParamsQuery,
   tallyParamsQuery,
   depositParamsQuery,
+  mintParamsQuery,
   distributionParamsQuery,
   stakingParamsQuery,
   ibcDenomTracesQuery,
@@ -188,6 +189,31 @@ describe("React Query Hook Tests for RPC Endpoints", () => {
           ],
         }
       `);
+    });
+  });
+
+  describe("mintParamsQuery Query", () => {
+    it("should return mint inflation params", async ({
+      api,
+      wrapper,
+    }: QueryTestContext) => {
+      const { result, waitFor } = renderHook(
+        () => useQuery(mintParamsQuery(api)),
+        {
+          wrapper,
+        },
+      );
+
+      await waitFor(() => result.current.isSuccess);
+      expect(result.current.data).toBeDefined();
+      expect(result.current.data).toMatchObject({
+        mint_denom: "ubld",
+      });
+      expect(result.current.data?.inflation_min).toMatch(/^0\.\d+$/);
+      expect(result.current.data?.inflation_max).toMatch(/^0\.\d+$/);
+      expect(result.current.data?.inflation_rate_change).toMatch(/^0\.\d+$/);
+      expect(result.current.data?.goal_bonded).toMatch(/^0\.\d+$/);
+      expect(result.current.data?.blocks_per_year).toMatch(/^\d+$/);
     });
   });
 

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -17,6 +17,7 @@ import type {
   VotingParams,
   DepositParams,
   TallyParams,
+  MintParams,
   DistributionParams,
   StakingParams,
 } from "../types/gov";
@@ -104,6 +105,18 @@ export const depositParamsQuery = (
     const res = await fetch(`${api}/cosmos/gov/v1beta1/params/deposit`);
     const data: GovParamsQueryResponse = await res.json();
     return data?.deposit_params;
+  },
+  enabled: !!api,
+});
+
+export const mintParamsQuery = (
+  api: string | undefined,
+): UseQueryOptions<MintParams, unknown> => ({
+  queryKey: ["mintParams", api],
+  queryFn: async (): Promise<MintParams> => {
+    const res = await fetch(`${api}/cosmos/mint/v1beta1/params`);
+    const data: { params: MintParams } = await res.json();
+    return data?.params;
   },
   enabled: !!api,
 });

--- a/src/lib/selectors.ts
+++ b/src/lib/selectors.ts
@@ -1,7 +1,12 @@
 import type { UseQueryResult } from "@tanstack/react-query";
 import type { SwingSetParams } from "../types/swingset";
 import type { Coin, BankBalances, DenomTrace } from "../types/bank";
-import { TallyParams, VotingParams, DepositParams } from "../types/gov";
+import {
+  TallyParams,
+  VotingParams,
+  DepositParams,
+  MintParams,
+} from "../types/gov";
 import { objectToArray } from "../utils/object";
 
 export type SelectorFn<T, R> = (
@@ -57,6 +62,25 @@ export const selectDepsoitParams = (
 ) => {
   if (!query?.data) return undefined;
   return objectToArray(query.data);
+};
+
+export const selectMintParams = (
+  query: UseQueryResult<MintParams, unknown>,
+) => {
+  if (!query?.data) return undefined;
+  const params = objectToArray(query.data);
+  if (!params) return undefined;
+  const keys = [
+    "mint_denom",
+    "inflation_min",
+    "inflation_max",
+    "inflation_rate_change",
+    "goal_bonded",
+    "blocks_per_year",
+  ];
+  return keys
+    .map((key) => params.find((param) => param.key === key))
+    .filter((param): param is { key: string; value: unknown } => !!param);
 };
 
 /** filter bank assets, so only ibc/* assets are returned */

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -20,6 +20,7 @@ export type ParameterChangeTypeDescriptor<
   valueKey?: string;
   transformColumn?: "ist";
   headers: string[];
+  readOnlyKeys?: string[];
   query: (
     api: string | undefined,
     walletAddress?: string,

--- a/src/types/gov.ts
+++ b/src/types/gov.ts
@@ -15,6 +15,15 @@ export type TallyParams = {
   veto_threshold: string; // string (dec) "0.334000000000000000"
 };
 
+export type MintParams = {
+  mint_denom: string;
+  inflation_rate_change: string;
+  inflation_max: string;
+  inflation_min: string;
+  goal_bonded: string;
+  blocks_per_year: string;
+};
+
 export type GovParamsQueryResponse = {
   voting_params: VotingParams;
   deposit_params: DepositParams;

--- a/src/utils/transactionParser.tsx
+++ b/src/utils/transactionParser.tsx
@@ -45,6 +45,9 @@ export function parseError(error: Error) {
   if (error.message.includes("proposal description cannot be blank")) {
     return "Proposal description cannot be blank.";
   }
+  if (error.message.includes("unknown subspace")) {
+    return "This parameter change type is not supported on this network.";
+  }
 
   return error.message;
 }


### PR DESCRIPTION
Closes #73

This PR closes #73 by adding working mint-parameter governance updates in the Agoric flow.

User-visible behavior:
- Adds `Mint Parameters` support using the governance path required by current Agoric SDK/Cosmos SDK behavior.
- Editable fields: `inflation_min`, `inflation_max`, `inflation_rate_change`, `goal_bonded`.
- Read-only fields shown for context: `mint_denom`, `blocks_per_year`.
- Wallet connect now requires a selected network.
- Parameter table edits now persist on blur/tab/outside-click (not only Enter/Save).

Validation run locally:
- `yarn lint`
- `yarn test`
- `yarn run build`


