### PR TITLE
fix: Install bundle should wait for tx

### DIFF
--- a/src/installBundle/installBundle.ts
+++ b/src/installBundle/installBundle.ts
@@ -185,6 +185,7 @@ export const installBundle = async (
     }
 
     for (let i = 0; i < chunks.length; i += 1) {
+      await new Promise(resolve => setTimeout(resolve, 15_000));
       const chunk = chunks[i];
       const proposalMsg = makeSendChunkMsg({
         chunkedArtifactId,

--- a/src/lib/signAndBroadcast.spec.tsx
+++ b/src/lib/signAndBroadcast.spec.tsx
@@ -17,7 +17,11 @@ vi.mock("@paralleldrive/cuid2", () => ({
 }));
 
 describe("makeSignAndBroadcast Unit Tests", () => {
-  let mockStargateClient: { simulate: Mock; signAndBroadcast: Mock };
+  let mockStargateClient: {
+    simulate: Mock;
+    signAndBroadcast: Mock;
+    getTx: Mock;
+  };
   let walletAddress: string;
   let netName: string;
   let proposalMsg: EncodeObject;
@@ -28,6 +32,7 @@ describe("makeSignAndBroadcast Unit Tests", () => {
     mockStargateClient = {
       simulate: vi.fn(),
       signAndBroadcast: vi.fn(),
+      getTx: vi.fn(),
     };
 
     walletAddress = "agoric12345";
@@ -45,11 +50,13 @@ describe("makeSignAndBroadcast Unit Tests", () => {
     const MOCK_GAS = 1000;
     const mockTxResult = {
       code: 0,
+      transactionHash: "DEADBEEF",
       events: [],
     };
 
     mockStargateClient.simulate.mockResolvedValue(MOCK_GAS);
     mockStargateClient.signAndBroadcast.mockResolvedValue(mockTxResult);
+    mockStargateClient.getTx.mockResolvedValue({ code: 0 });
 
     const signAndBroadcast = makeSignAndBroadcast(
       // @ts-expect-error mock stargateClient

--- a/src/lib/signAndBroadcast.tsx
+++ b/src/lib/signAndBroadcast.tsx
@@ -41,6 +41,7 @@ export const makeSignAndBroadcast =
         [proposalMsg],
         makeFeeObject({ gas }),
       );
+      console.info('txResult', txResult);
       assertIsDeliverTxSuccess(txResult);
       // Poll until the node confirms the transaction is indexed, so that
       // state changes from this block are available for subsequent simulate/
@@ -50,6 +51,7 @@ export const makeSignAndBroadcast =
       const maxAttempts = 30;
       for (let i = 0; i < maxAttempts; i++) {
         const indexed = await stargateClient.getTx(transactionHash);
+        console.info('IndexedTx', indexed);
         if (indexed) {
           if (indexed.code !== 0) {
             throw new Error(

--- a/src/lib/signAndBroadcast.tsx
+++ b/src/lib/signAndBroadcast.tsx
@@ -42,6 +42,24 @@ export const makeSignAndBroadcast =
         makeFeeObject({ gas }),
       );
       assertIsDeliverTxSuccess(txResult);
+      // Poll until the node confirms the transaction is indexed, so that
+      // state changes from this block are available for subsequent simulate/
+      // execute calls (e.g. chunk submissions after a manifest).
+      const { transactionHash } = txResult;
+      const pollIntervalMs = 1_000;
+      const maxAttempts = 30;
+      for (let i = 0; i < maxAttempts; i++) {
+        const indexed = await stargateClient.getTx(transactionHash);
+        if (indexed) {
+          if (indexed.code !== 0) {
+            throw new Error(
+              `Transaction ${transactionHash} failed on-chain with code ${indexed.code}`,
+            );
+          }
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+      }
     } catch (e) {
       toast.update(toastId, {
         render: parseError(e as Error),


### PR DESCRIPTION
For multi-node chains (production), we need to wait for the manifest transaction to be submitted and processed at an indexed block height. This adds a loop to poll for that event.