### PR TITLE
Feature flag for bundle chunking

### DIFF
--- a/src/components/EditableTable.tsx
+++ b/src/components/EditableTable.tsx
@@ -63,7 +63,7 @@ const EditableTable = ({
   const shouldTransform = typeof transformValue === "function";
 
   const resolvedHeaders = shouldTransform
-    ? [...headers, transformedLabel ?? (headers.at(-1) as string)]
+    ? [...headers, transformedLabel ?? (headers[headers.length - 1] as string)]
     : headers;
 
   const renderRow = (row: RowValue) => {

--- a/src/config/agoric/agoric.tsx
+++ b/src/config/agoric/agoric.tsx
@@ -59,8 +59,14 @@ const Agoric = () => {
     clipboard: window.navigator.clipboard,
   });
 
+  const enableChunking = useMemo(() => {
+    const params = new URLSearchParams(window.location.search);
+    return params.has("enable-chunking");
+  }, []);
+
   const swingSetParams = useQuery(swingSetParamsQuery(api));
   const chunkSizeLimit = (({ isLoading, data }) => {
+    if (!enableChunking) return Infinity;
     if (isLoading || !data) {
       return Infinity;
     }


### PR DESCRIPTION
We have a temporary need to disable bundle chunking until chains that support bundle chunking reliably default to a non-zero deadline in their swingset parameters. This places the feature behind a flag, expressible in the query string, `?enable-chunking`.