### PR TITLE
Allow enable-chunking flag to override chunk size limit

### DIFF
--- a/src/config/agoric/agoric.spec.tsx
+++ b/src/config/agoric/agoric.spec.tsx
@@ -4,7 +4,7 @@ import { Router } from "wouter";
 import App from "../../App";
 import { ContextProviders } from "../../contexts/providers";
 import { memoryLocation } from "../../test-utils";
-import { parseEnableChunking } from "./agoric";
+import { parseEnableChunking } from "./enableChunking";
 
 describe("Agoric Config", () => {
   it("renders proposal type tabs", async () => {
@@ -61,45 +61,44 @@ describe("Agoric Config", () => {
 
 describe("parseEnableChunking", () => {
   it("returns disabled when the param is absent", () => {
-    expect(parseEnableChunking("")).toEqual({
-      enableChunking: false,
-      chunkSizeOverride: null,
-      invalidOverrideRaw: null,
-    });
-    expect(parseEnableChunking("?other=1")).toEqual({
-      enableChunking: false,
-      chunkSizeOverride: null,
-      invalidOverrideRaw: null,
-    });
+    expect(parseEnableChunking("")).toEqual({ kind: "disabled" });
+    expect(parseEnableChunking("?other=1")).toEqual({ kind: "disabled" });
   });
 
   it("enables without an override when the param is present but valueless", () => {
     expect(parseEnableChunking("?enable-chunking")).toEqual({
-      enableChunking: true,
-      chunkSizeOverride: null,
-      invalidOverrideRaw: null,
+      kind: "enabled",
     });
     expect(parseEnableChunking("?enable-chunking=")).toEqual({
-      enableChunking: true,
-      chunkSizeOverride: null,
-      invalidOverrideRaw: null,
+      kind: "enabled",
     });
   });
 
   it("accepts a positive integer override", () => {
     expect(parseEnableChunking("?enable-chunking=50000")).toEqual({
-      enableChunking: true,
-      chunkSizeOverride: 50000,
-      invalidOverrideRaw: null,
+      kind: "override",
+      bytes: 50000,
     });
+  });
+
+  it("accepts a search string without a leading `?`", () => {
+    expect(parseEnableChunking("enable-chunking=50000")).toEqual({
+      kind: "override",
+      bytes: 50000,
+    });
+  });
+
+  it("takes the first occurrence when the param is repeated", () => {
+    expect(
+      parseEnableChunking("?enable-chunking=10&enable-chunking=20"),
+    ).toEqual({ kind: "override", bytes: 10 });
   });
 
   it("rejects non-positive, non-integer, and non-numeric values, surfacing the raw", () => {
     for (const bad of ["0", "-5", "1.5", "abc"]) {
       expect(parseEnableChunking(`?enable-chunking=${bad}`)).toEqual({
-        enableChunking: true,
-        chunkSizeOverride: null,
-        invalidOverrideRaw: bad,
+        kind: "invalid",
+        raw: bad,
       });
     }
   });

--- a/src/config/agoric/agoric.spec.tsx
+++ b/src/config/agoric/agoric.spec.tsx
@@ -4,6 +4,7 @@ import { Router } from "wouter";
 import App from "../../App";
 import { ContextProviders } from "../../contexts/providers";
 import { memoryLocation } from "../../test-utils";
+import { parseEnableChunking } from "./agoric";
 
 describe("Agoric Config", () => {
   it("renders proposal type tabs", async () => {
@@ -55,5 +56,51 @@ describe("Agoric Config", () => {
 
     fireEvent.change(recipientField, { target: { value: "agoric12se" } });
     fireEvent.change(amountField, { target: { value: "1000000" } });
+  });
+});
+
+describe("parseEnableChunking", () => {
+  it("returns disabled when the param is absent", () => {
+    expect(parseEnableChunking("")).toEqual({
+      enableChunking: false,
+      chunkSizeOverride: null,
+      invalidOverrideRaw: null,
+    });
+    expect(parseEnableChunking("?other=1")).toEqual({
+      enableChunking: false,
+      chunkSizeOverride: null,
+      invalidOverrideRaw: null,
+    });
+  });
+
+  it("enables without an override when the param is present but valueless", () => {
+    expect(parseEnableChunking("?enable-chunking")).toEqual({
+      enableChunking: true,
+      chunkSizeOverride: null,
+      invalidOverrideRaw: null,
+    });
+    expect(parseEnableChunking("?enable-chunking=")).toEqual({
+      enableChunking: true,
+      chunkSizeOverride: null,
+      invalidOverrideRaw: null,
+    });
+  });
+
+  it("accepts a positive integer override", () => {
+    expect(parseEnableChunking("?enable-chunking=50000")).toEqual({
+      enableChunking: true,
+      chunkSizeOverride: 50000,
+      invalidOverrideRaw: null,
+    });
+  });
+
+  it("rejects non-positive, non-integer, and non-numeric values, surfacing the raw", () => {
+    for (const bad of ["0", "-5", "1.5", "abc"]) {
+      expect(parseEnableChunking(`?enable-chunking=${bad}`)).toEqual({
+        enableChunking: true,
+        chunkSizeOverride: null,
+        invalidOverrideRaw: bad,
+      });
+    }
   });
 });

--- a/src/config/agoric/agoric.tsx
+++ b/src/config/agoric/agoric.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "react-toastify";
 import { Code } from "../../components/inline";
 import { BundleForm, BundleFormArgs } from "../../components/BundleForm";
@@ -59,14 +59,50 @@ const Agoric = () => {
     clipboard: window.navigator.clipboard,
   });
 
-  const enableChunking = useMemo(() => {
+  const { enableChunking, chunkSizeOverride, invalidOverrideRaw } = useMemo(() => {
     const params = new URLSearchParams(window.location.search);
-    return params.has("enable-chunking");
+    if (!params.has("enable-chunking")) {
+      return {
+        enableChunking: false,
+        chunkSizeOverride: null,
+        invalidOverrideRaw: null,
+      };
+    }
+    const raw = params.get("enable-chunking");
+    if (raw === null || raw === "") {
+      return {
+        enableChunking: true,
+        chunkSizeOverride: null,
+        invalidOverrideRaw: null,
+      };
+    }
+    const parsed = Number(raw);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      return {
+        enableChunking: true,
+        chunkSizeOverride: null,
+        invalidOverrideRaw: raw,
+      };
+    }
+    return {
+      enableChunking: true,
+      chunkSizeOverride: parsed,
+      invalidOverrideRaw: null,
+    };
   }, []);
+
+  useEffect(() => {
+    if (invalidOverrideRaw === null) return;
+    toast.warn(
+      `Ignoring invalid enable-chunking value ${JSON.stringify(invalidOverrideRaw)}; ` +
+        `expected a positive integer byte count. Falling back to chain config.`,
+    );
+  }, [invalidOverrideRaw]);
 
   const swingSetParams = useQuery(swingSetParamsQuery(api));
   const chunkSizeLimit = (({ isLoading, data }) => {
     if (!enableChunking) return Infinity;
+    if (chunkSizeOverride !== null) return chunkSizeOverride;
     if (isLoading || !data) {
       return Infinity;
     }

--- a/src/config/agoric/agoric.tsx
+++ b/src/config/agoric/agoric.tsx
@@ -59,8 +59,8 @@ const Agoric = () => {
     clipboard: window.navigator.clipboard,
   });
 
-  const { enableChunking, chunkSizeOverride, invalidOverrideRaw } = useMemo(
-    () => {
+  const { enableChunking, chunkSizeOverride, invalidOverrideRaw } =
+    useMemo(() => {
       const params = new URLSearchParams(window.location.search);
       if (!params.has("enable-chunking")) {
         return {
@@ -90,9 +90,7 @@ const Agoric = () => {
         chunkSizeOverride: parsed,
         invalidOverrideRaw: null,
       };
-    },
-    [],
-  );
+    }, []);
 
   useEffect(() => {
     if (invalidOverrideRaw === null) return;

--- a/src/config/agoric/agoric.tsx
+++ b/src/config/agoric/agoric.tsx
@@ -48,6 +48,44 @@ const pluralizeEn = (count: number, singular: string, plural: string) => {
   return category === "one" ? `${count} ${singular}` : `${count} ${plural}`;
 };
 
+type EnableChunkingState = {
+  enableChunking: boolean;
+  chunkSizeOverride: number | null;
+  invalidOverrideRaw: string | null;
+};
+
+export const parseEnableChunking = (search: string): EnableChunkingState => {
+  const params = new URLSearchParams(search);
+  if (!params.has("enable-chunking")) {
+    return {
+      enableChunking: false,
+      chunkSizeOverride: null,
+      invalidOverrideRaw: null,
+    };
+  }
+  const raw = params.get("enable-chunking");
+  if (raw === null || raw === "") {
+    return {
+      enableChunking: true,
+      chunkSizeOverride: null,
+      invalidOverrideRaw: null,
+    };
+  }
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return {
+      enableChunking: true,
+      chunkSizeOverride: null,
+      invalidOverrideRaw: raw,
+    };
+  }
+  return {
+    enableChunking: true,
+    chunkSizeOverride: parsed,
+    invalidOverrideRaw: null,
+  };
+};
+
 const Agoric = () => {
   const { netName, networkConfig } = useNetwork();
   const { api } = useNetwork();
@@ -59,44 +97,17 @@ const Agoric = () => {
     clipboard: window.navigator.clipboard,
   });
 
-  const { enableChunking, chunkSizeOverride, invalidOverrideRaw } =
-    useMemo(() => {
-      const params = new URLSearchParams(window.location.search);
-      if (!params.has("enable-chunking")) {
-        return {
-          enableChunking: false,
-          chunkSizeOverride: null,
-          invalidOverrideRaw: null,
-        };
-      }
-      const raw = params.get("enable-chunking");
-      if (raw === null || raw === "") {
-        return {
-          enableChunking: true,
-          chunkSizeOverride: null,
-          invalidOverrideRaw: null,
-        };
-      }
-      const parsed = Number(raw);
-      if (!Number.isInteger(parsed) || parsed <= 0) {
-        return {
-          enableChunking: true,
-          chunkSizeOverride: null,
-          invalidOverrideRaw: raw,
-        };
-      }
-      return {
-        enableChunking: true,
-        chunkSizeOverride: parsed,
-        invalidOverrideRaw: null,
-      };
-    }, []);
+  const { enableChunking, chunkSizeOverride, invalidOverrideRaw } = useMemo(
+    () => parseEnableChunking(window.location.search),
+    [],
+  );
 
   useEffect(() => {
     if (invalidOverrideRaw === null) return;
     toast.warn(
       `Ignoring invalid enable-chunking value ${JSON.stringify(invalidOverrideRaw)}; ` +
         `expected a positive integer byte count. Falling back to chain config.`,
+      { toastId: `enable-chunking-invalid-${invalidOverrideRaw}` },
     );
   }, [invalidOverrideRaw]);
 

--- a/src/config/agoric/agoric.tsx
+++ b/src/config/agoric/agoric.tsx
@@ -29,6 +29,7 @@ import {
 } from "../../lib/queries.ts";
 import { selectCoinBalance } from "../../lib/selectors.ts";
 import { DepositParams, VotingParams } from "../../types/gov.ts";
+import { parseEnableChunking } from "./enableChunking";
 
 const locale = "en";
 
@@ -48,44 +49,6 @@ const pluralizeEn = (count: number, singular: string, plural: string) => {
   return category === "one" ? `${count} ${singular}` : `${count} ${plural}`;
 };
 
-type EnableChunkingState = {
-  enableChunking: boolean;
-  chunkSizeOverride: number | null;
-  invalidOverrideRaw: string | null;
-};
-
-export const parseEnableChunking = (search: string): EnableChunkingState => {
-  const params = new URLSearchParams(search);
-  if (!params.has("enable-chunking")) {
-    return {
-      enableChunking: false,
-      chunkSizeOverride: null,
-      invalidOverrideRaw: null,
-    };
-  }
-  const raw = params.get("enable-chunking");
-  if (raw === null || raw === "") {
-    return {
-      enableChunking: true,
-      chunkSizeOverride: null,
-      invalidOverrideRaw: null,
-    };
-  }
-  const parsed = Number(raw);
-  if (!Number.isInteger(parsed) || parsed <= 0) {
-    return {
-      enableChunking: true,
-      chunkSizeOverride: null,
-      invalidOverrideRaw: raw,
-    };
-  }
-  return {
-    enableChunking: true,
-    chunkSizeOverride: parsed,
-    invalidOverrideRaw: null,
-  };
-};
-
 const Agoric = () => {
   const { netName, networkConfig } = useNetwork();
   const { api } = useNetwork();
@@ -97,24 +60,25 @@ const Agoric = () => {
     clipboard: window.navigator.clipboard,
   });
 
-  const { enableChunking, chunkSizeOverride, invalidOverrideRaw } = useMemo(
+  const chunkingState = useMemo(
     () => parseEnableChunking(window.location.search),
     [],
   );
 
+  const warnedRef = useRef(false);
   useEffect(() => {
-    if (invalidOverrideRaw === null) return;
+    if (chunkingState.kind !== "invalid" || warnedRef.current) return;
+    warnedRef.current = true;
     toast.warn(
-      `Ignoring invalid enable-chunking value ${JSON.stringify(invalidOverrideRaw)}; ` +
-        `expected a positive integer byte count. Falling back to chain config.`,
-      { toastId: `enable-chunking-invalid-${invalidOverrideRaw}` },
+      `Ignoring invalid enable-chunking value ${JSON.stringify(chunkingState.raw)}; ` +
+        `expected a positive integer byte count. Using the chain's chunk_size_limit_bytes instead.`,
     );
-  }, [invalidOverrideRaw]);
+  }, [chunkingState]);
 
   const swingSetParams = useQuery(swingSetParamsQuery(api));
   const chunkSizeLimit = (({ isLoading, data }) => {
-    if (!enableChunking) return Infinity;
-    if (chunkSizeOverride !== null) return chunkSizeOverride;
+    if (chunkingState.kind === "disabled") return Infinity;
+    if (chunkingState.kind === "override") return chunkingState.bytes;
     if (isLoading || !data) {
       return Infinity;
     }

--- a/src/config/agoric/agoric.tsx
+++ b/src/config/agoric/agoric.tsx
@@ -59,37 +59,40 @@ const Agoric = () => {
     clipboard: window.navigator.clipboard,
   });
 
-  const { enableChunking, chunkSizeOverride, invalidOverrideRaw } = useMemo(() => {
-    const params = new URLSearchParams(window.location.search);
-    if (!params.has("enable-chunking")) {
-      return {
-        enableChunking: false,
-        chunkSizeOverride: null,
-        invalidOverrideRaw: null,
-      };
-    }
-    const raw = params.get("enable-chunking");
-    if (raw === null || raw === "") {
+  const { enableChunking, chunkSizeOverride, invalidOverrideRaw } = useMemo(
+    () => {
+      const params = new URLSearchParams(window.location.search);
+      if (!params.has("enable-chunking")) {
+        return {
+          enableChunking: false,
+          chunkSizeOverride: null,
+          invalidOverrideRaw: null,
+        };
+      }
+      const raw = params.get("enable-chunking");
+      if (raw === null || raw === "") {
+        return {
+          enableChunking: true,
+          chunkSizeOverride: null,
+          invalidOverrideRaw: null,
+        };
+      }
+      const parsed = Number(raw);
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        return {
+          enableChunking: true,
+          chunkSizeOverride: null,
+          invalidOverrideRaw: raw,
+        };
+      }
       return {
         enableChunking: true,
-        chunkSizeOverride: null,
+        chunkSizeOverride: parsed,
         invalidOverrideRaw: null,
       };
-    }
-    const parsed = Number(raw);
-    if (!Number.isInteger(parsed) || parsed <= 0) {
-      return {
-        enableChunking: true,
-        chunkSizeOverride: null,
-        invalidOverrideRaw: raw,
-      };
-    }
-    return {
-      enableChunking: true,
-      chunkSizeOverride: parsed,
-      invalidOverrideRaw: null,
-    };
-  }, []);
+    },
+    [],
+  );
 
   useEffect(() => {
     if (invalidOverrideRaw === null) return;

--- a/src/config/agoric/agoric.tsx
+++ b/src/config/agoric/agoric.tsx
@@ -159,7 +159,7 @@ const Agoric = () => {
         const txCount = chunkCount + 1;
         const txEn = pluralizeEn(txCount, "transaction", "transactions");
         const chunkEn = pluralizeEn(chunkCount, "chunk", "chunks");
-        const txSummary = `Submitting bundle in ${txCount} ${txEn} (1 manifest and ${chunkCount} ${chunkEn})`;
+        const txSummary = `Submitting bundle in ${txEn} (1 manifest and ${chunkEn})`;
         toast.info([txSummary, ...txInfo].join(", "));
       },
     });

--- a/src/config/agoric/enableChunking.ts
+++ b/src/config/agoric/enableChunking.ts
@@ -1,0 +1,15 @@
+export type EnableChunkingState =
+  | { kind: "disabled" }
+  | { kind: "enabled" }
+  | { kind: "override"; bytes: number }
+  | { kind: "invalid"; raw: string };
+
+export const parseEnableChunking = (search: string): EnableChunkingState => {
+  const params = new URLSearchParams(search);
+  if (!params.has("enable-chunking")) return { kind: "disabled" };
+  const raw = params.get("enable-chunking");
+  if (raw === null || raw === "") return { kind: "enabled" };
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) return { kind: "invalid", raw };
+  return { kind: "override", bytes: parsed };
+};


### PR DESCRIPTION
## Summary
- Extend the `?enable-chunking` URL flag to accept an optional positive-integer byte count (e.g. `?enable-chunking=50000`) that overrides the chain's configured `chunk_size_limit_bytes` for manual testing.
- Presence-only behavior (`?enable-chunking`) is unchanged — still uses the chain config.
- Invalid values (non-integer, zero, negative) fall back to the chain config and pop a `toast.warn` so the tester notices the typo.

## Test plan
- [ ] No flag → bundles install in one transaction (chain limit ignored).
- [ ] `?enable-chunking` → small bundles single-tx, bundles above chain limit chunked.
- [ ] `?enable-chunking=10000` → preflight toast reports N chunks ≈ ceil(compressedSize / 10000).
- [ ] `?enable-chunking=999999999` → normally-chunked bundle goes single-tx.
- [ ] `?enable-chunking=abc` / `=0` / `=-5` / `=1.5` → warning toast on load, behaves as presence-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)